### PR TITLE
Fix NoMethodError and TypeError about _make_complex_eigvecs method

### DIFF
--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -996,7 +996,7 @@ module Numo; module Linalg
   def _make_complex_eigvecs(w, vin) # :nodoc:
     v = w.class.cast(vin)
     # broadcast to vin.shape
-    m = (w.imag > 0 | Bit.zeros(*vin.shape)).where
+    m = ((w.imag > 0) | Bit.zeros(*vin.shape)).where
     v[m].imag = vin[m+1]
     v[m+1] = v[m].conj
     v

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -992,8 +992,6 @@ module Numo; module Linalg
     end
   end
 
-  private
-
   # @!visibility private
   def _make_complex_eigvecs(w, vin) # :nodoc:
     v = w.class.cast(vin)
@@ -1003,6 +1001,8 @@ module Numo; module Linalg
     v[m+1] = v[m].conj
     v
   end
+
+  private_class_method :_make_complex_eigvecs
 
 end
 end


### PR DESCRIPTION
This pull request fixes the bugs about the `_make_complex_eigvecs` method.
To make class methods in Module private, it should to use the `private_class_method` method.
In addition, the `|` operator has higher precedence than the `>` operator.

I found the bugs when I gave a matrix of Numo::DFloat to the Numo::Linalg::eig method.

```ruby
x = Numo::DFloat.new(3, 3).rand
Numo::Linalg::eig(x)
```