### PR TITLE
Add new option specifying the range of eigenvalues to the eigh and eigvalsh methods

### DIFF
--- a/ext/numo/linalg/lapack/gen/spec.rb
+++ b/ext/numo/linalg/lapack/gen/spec.rb
@@ -6,6 +6,9 @@ def_id "jobz"
 def_id "jobvl"
 def_id "jobvr"
 def_id "trans"
+def_id "range"
+def_id "il"
+def_id "iu"
 def_id "rcond"
 def_id "itype"
 def_id "norm"
@@ -58,11 +61,13 @@ when /c|z/
   decl "?heevd", "syev"
   decl "?hegv", "sygv"
   decl "?hegvd", "sygv"
+  decl "?hegvx", "sygvx"
 else
   decl "?syev"
   decl "?syevd", "syev"
   decl "?sygv"
   decl "?sygvd", "sygv"
+  decl "?sygvx"
 end
 
 # factorize

--- a/ext/numo/linalg/lapack/lapack.c
+++ b/ext/numo/linalg/lapack/lapack.c
@@ -125,6 +125,35 @@ numo_lapacke_option_job(VALUE job, char true_char, char false_char)
 }
 
 char
+numo_lapacke_option_range(VALUE job, char true_char, char false_char)
+{
+    char *ptr, c;
+
+    switch(TYPE(job)) {
+    case T_NIL:
+    case T_UNDEF:
+    case T_TRUE:
+        return true_char;
+    case T_FALSE:
+        return false_char;
+    case T_SYMBOL:
+        job = rb_sym2str(job);
+    case T_STRING:
+        ptr = RSTRING_PTR(job);
+        if (RSTRING_LEN(job) > 0) {
+            c = ptr[0];
+            if (c >= 'a' && c <= 'z') {
+                c -= 'a'-'A';
+            }
+            return c;
+        }
+        break;
+    }
+    rb_raise(rb_eArgError,"invalid value for JOB option");
+    return 0;
+}
+
+char
 numo_lapacke_option_trans(VALUE trans)
 {
     int opt;

--- a/ext/numo/linalg/lapack/numo_lapack.h
+++ b/ext/numo/linalg/lapack/numo_lapack.h
@@ -15,6 +15,9 @@ extern int numo_lapacke_option_order(VALUE order);
 #define option_job numo_lapacke_option_job
 extern char numo_lapacke_option_job(VALUE job, char true_char, char false_char);
 
+#define option_range numo_lapacke_option_range
+extern char numo_lapacke_option_range(VALUE range, char true_char, char false_char);
+
 #define option_trans numo_lapacke_option_trans
 extern char numo_lapacke_option_trans(VALUE trans);
 

--- a/ext/numo/linalg/lapack/tmpl/sygvx.c
+++ b/ext/numo/linalg/lapack/tmpl/sygvx.c
@@ -1,0 +1,130 @@
+#define args_t <%=func_name%>_args_t
+#define func_p <%=func_name%>_p
+
+typedef struct {
+    int order;
+    int itype;
+    char jobz;
+    char uplo;
+    char range;
+    int il;
+    int iu;
+} args_t;
+
+static <%=func_name%>_t func_p = 0;
+
+static void
+<%=c_iter%>(na_loop_t * const lp)
+{
+    dtype *a, *b, *z;
+    rtype *w;
+    int   *ifail;
+    int   *info;
+    int    m, n, lda, ldb, ldz, il, iu;
+    rtype  vl, vu;
+    rtype  abstol = 0;
+
+    args_t *g;
+
+    a = (dtype*)NDL_PTR(lp, 0);
+    b = (dtype*)NDL_PTR(lp, 1);
+    w = (rtype*)NDL_PTR(lp, 2);
+    z = (dtype*)NDL_PTR(lp, 3);
+    ifail = (int*)NDL_PTR(lp, 4);
+    info = (int*)NDL_PTR(lp, 5);
+    g = (args_t*)(lp->opt_ptr);
+
+    n = NDL_SHAPE(lp, 0)[1];
+    lda = NDL_STEP(lp, 0) / sizeof(dtype);
+    ldb = NDL_STEP(lp, 1) / sizeof(dtype);
+    ldz = NDL_SHAPE(lp, 3)[1];
+
+    *info = (*func_p)( g->order, g->itype, g->jobz, g->range, g->uplo, n, a, lda, b, ldb,
+                       vl, vu, g->il, g->iu, abstol, &m, w, z, ldz, ifail );
+
+    CHECK_ERROR(*info);
+}
+
+/*
+<%
+params = [
+  mat("a",:inplace),
+  mat("b",:inplace),
+  "@param [Integer] itype Specifies the problem type to be solved.  If 1:  A*x = (lambda)*B*x, If 2:  A*B*x = (lambda)*x, If 3:  B*A*x = (lambda)*x.",
+  jobe("jobz"),
+  opt("uplo"),
+  opt("order"),
+  "@param [String or Symbol] range If 'A': Compute all eigenvalues, if 'I': Compute eigenvalues with indices il to iu (default='A')",
+  "@param [Integer] il Specifies the index of the smallest eigenvalue in ascending order to be returned. If range = 'A', il is not referenced.",
+  "@param [Integer] iu Specifies the index of the largest eigenvalue in ascending order to be returned. Constraint: 1<=il<=iu<=N. If range = 'A', iu is not referenced.",
+].select{|x| x}.join("\n  ")
+return_name="a, b, w, z, ifail, info"
+%>
+  @overload <%=name%>(a, b, [itype:1, jobz:'V', uplo:'U', order:'R', range:'I', il: 1, il: 2])
+  <%=params%>
+  @return [[<%=return_name%>]]
+    Array<<%=real_class_name%>,<%=real_class_name%>,<%=real_class_name%>,<%=real_class_name%>,<%=real_class_name%>,Integer>
+<%=outparam(return_name)%>
+
+<%=description%>
+*/
+
+static VALUE
+<%=c_func(-1)%>(int argc, VALUE const argv[], VALUE UNUSED(mod))
+{
+    VALUE a, b, ans;
+    int   n, nb, m;
+    narray_t *na1, *na2;
+    size_t w_shape[1];
+    size_t z_shape[2];
+    size_t ifail_shape[1];
+
+    ndfunc_arg_in_t ain[2] = {{OVERWRITE, 2}, {OVERWRITE, 2}};
+    ndfunc_arg_out_t aout[4] = {{cRT, 1, w_shape}, {cT, 2, z_shape}, {cI, 1, ifail_shape}, {cInt, 0}};
+    ndfunc_t ndf = {&<%=c_iter%>, NO_LOOP | NDF_EXTRACT, 2, 4, ain, aout};
+
+    args_t g;
+    VALUE opts[7] = {Qundef, Qundef, Qundef, Qundef, Qundef, Qundef, Qundef};
+    VALUE kw_hash = Qnil;
+    ID kw_table[7] = {id_order, id_jobz, id_uplo, id_itype, id_range, id_il, id_iu};
+
+    CHECK_FUNC(func_p,"<%=func_name%>");
+
+    rb_scan_args(argc, argv, "2:", &a, &b, &kw_hash);
+    rb_get_kwargs(kw_hash, kw_table, 0, 7, opts);
+    g.order = option_order(opts[0]);
+    g.jobz = option_job(opts[1], 'V', 'N');
+    g.uplo = option_uplo(opts[2]);
+    g.itype = NUM2INT(option_value(opts[3], INT2FIX(1)));
+    g.range = option_range(opts[4], 'A', 'I');
+    g.il = NUM2INT(option_value(opts[5], INT2FIX(1)));
+    g.iu = NUM2INT(option_value(opts[6], INT2FIX(1)));
+
+    COPY_OR_CAST_TO(a, cT);
+    GetNArray(a, na1);
+    CHECK_DIM_GE(na1, 2);
+
+    COPY_OR_CAST_TO(b, cT);
+    GetNArray(b, na2);
+    CHECK_DIM_GE(na2, 2);
+    CHECK_SQUARE("matrix a", na1);
+    n  = COL_SIZE(na1);
+    CHECK_SQUARE("matrix b", na2);
+    nb = COL_SIZE(na2);
+    if (n != nb) {
+        rb_raise(nary_eShapeError, "matrix a and b must have same size");
+    }
+
+    m = g.range == 'I' ? g.iu - g.il + 1 : n;
+    w_shape[0] = m;
+    z_shape[0] = n;
+    z_shape[1] = m;
+    ifail_shape[0] = m;
+
+    ans = na_ndloop3(&ndf, &g, 2, a, b);
+
+    return rb_ary_new3(6, a, b, RARRAY_AREF(ans, 0), RARRAY_AREF(ans, 1), RARRAY_AREF(ans, 2), RARRAY_AREF(ans, 3));
+}
+
+#undef args_t
+#undef func_p

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -534,23 +534,22 @@ module Numo; module Linalg
     w
   end
 
-  # Computes the eigenvalues for a square symmetric/hermitian matrix A.
+  # Obtains the eigenvalues by solving an ordinary or generalized eigenvalue problem
+  # for a square symmetric / Hermitian matrix.
   #
   # @param a [Numo::NArray] square symmetric/hermitian matrix
   #   (>= 2-dimensinal NArray)
+  # @param b [Numo::NArray] (optional) square symmetric matrix (>= 2-dimensinal NArray)
+  #   If nil, identity matrix is assumed.
+  # @param vals_range [Range] (optional)
+  #   The range of indices of the eigenvalues (in ascending order) to be returned.
+  #   If nil or 0...N (N is the size of the matrix a), all eigenvalues are returned.
   # @param uplo [String or Symbol] (optional, default='U')
   #   Access upper ('U') or lower ('L') triangle.
   # @return [Numo::NArray] eigenvalues
 
-  def eigvalsh(a, uplo:false, turbo:false)
-    jobz = 'N' # jobz: Compute eigenvalues and eigenvectors.
-    case blas_char(a)
-    when /c|z/
-      func = turbo ? :hegv : :heev
-    else
-      func = turbo ? :sygv : :syev
-    end
-    Lapack.call(func, a, uplo:uplo, jobz:jobz)[0]
+  def eigvalsh(a, b=nil, vals_range:nil, uplo:'U', turbo:false)
+    eigh(a, b, vals_only: true, vals_range: vals_range, uplo: uplo, turbo: turbo).first
   end
 
 


### PR DESCRIPTION
## Purpose
I would like to add new option named `vals_range` to the `eigh` and `eigvalsh` method. The vals_range option specifies the range of indices of the eigenvalues (and corresponding eigenvectors) to be calculated.

## Why need
Most machine learning algorithms including calculation of eigenvalue problem such as Principal Component Analysis do not require all eigenvalues and eigenvectors. If it is possible to specify the range of eigenvalues required in the eigh method, execution of these algorithms is speeded up.

## Approach
The `sygvx` function in LAPACK can select the indices of eigenvalues and eigenvectors to be calculated. I added new template for sygvx function, and then fixed the codes of the eigh and eigvalsh method to call sygvx function.

## Usage
When calculating 10 small eigenvalues and corresponding eigenvectors of a symmetric matrix of size 100: 
```ruby
# a = Numo::DFloat.new(100, 100).rand
# a = 0.5 * (a + a.transpose)
Numo::Linalg.eigh(a, vals_range: 0..10)
```
Or
```ruby
Numo::Linalg.eigh(a, vals_range: [0, 10])
```

## Test
By running the following code, I confirmed the codes in this pull request work well.

https://gist.github.com/yoshoku/e52f015ff838777e123b93829501351f