### PR TITLE
Fix the UPCAST reference processing in the blas_char method

### DIFF
--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -499,9 +499,8 @@ module Numo; module Linalg
 
   def eigh(a, b=nil, vals_only:false, vals_range:nil, uplo:'U', turbo:false)
     jobz = vals_only ? 'N' : 'V' # jobz: Compute eigenvalues and eigenvectors.
-    func = blas_char(a) =~ /c|z/ ? 'hegv' : 'sygv'
     b = a.class.eye(a.shape[0]) if b.nil?
-    blas_char(b) # for checking that b is a matrix.
+    func = blas_char(a, b) =~ /c|z/ ? 'hegv' : 'sygv'
     if vals_range.nil?
       func << 'd' if turbo
       v, u_, w, = Lapack.call(func.to_sym, a, b, uplo: uplo, jobz: jobz)

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -65,7 +65,7 @@ module Numo; module Linalg
           NArray.array_type(a)
         end
       if k && k < NArray
-        t = k::UPCAST[t]
+        t = k::UPCAST[t] || t::UPCAST[k]
       end
     end
     BLAS_CHAR[t] || raise(TypeError,"invalid data type for BLAS/LAPACK")


### PR DESCRIPTION
## Problem
I found that performing the dot method with DFloat and DComplex fails on Numo::Linalg.

```ruby
> require 'numo/narray'
=> true
> a=Numo::DFloat.new(2,2).rand
=> Numo::DFloat#shape=[2,2]
[[0.0617545, 0.373067],
 [0.794815, 0.201042]]
> b=Numo::DComplex.new(2,2).rand
=> Numo::DComplex#shape=[2,2]
[[0.165089+0.0508827i, 0.108065+0.0687079i],
 [0.904121+0.478644i, 0.342969+0.164541i]]
> a.dot(b)
=> Numo::DComplex#shape=[2,2]
[[0.0687551+0.0402282i, 0.0736595+0.071196i],
 [0.125421+0.283672i, 0.450884+0.60024i]]

> require ‘numo/linalg/autoloader’
=> true
> a.dot(b)
TypeError: invalid data type for BLAS/LAPACK
…
```

## Solution
I thought that the cause of this failure lies in the reference processing of UPCAST in the blas_char method. [The specification about UPCAST](https://github.com/ruby-numo/numo-narray/wiki/Numo::NArray%E6%A6%82%E8%A6%81#upcast) is written as follows;  When the Int8 type not included in Numo::Int32::UPCAST, it checks Numo::Int8::UPCAST. However, in the blas method, if the type is not included in UPCAST, it returns nil and stops referring. Thus, I fixed to refer to UPCAST for each other. 

In addition, I fixed the type checking in the eigh method to simple codes.

## Test
```ruby
> require 'numo/linalg/autoloader'
=> true
> a=Numo::DFloat.new(2,2).rand
=> Numo::DFloat#shape=[2,2]
[[0.0617545, 0.373067],
 [0.794815, 0.201042]]
> b=Numo::DComplex.new(2,2).rand
=> Numo::DComplex#shape=[2,2]
[[0.116041+0.344032i, 0.539948+0.737815i],
 [0.165089+0.0508827i, 0.108065+0.0687079i]]
> a.dot(b)
=> Numo::DComplex#shape=[2,2]
[[0.0687551+0.0402282i, 0.0736595+0.071196i],
 [0.125421+0.283672i, 0.450884+0.60024i]]
```