### PR TITLE
Suppress debug message on QR decomposition method

### DIFF
--- a/ext/numo/linalg/lapack/tmpl/gqr.c
+++ b/ext/numo/linalg/lapack/tmpl/gqr.c
@@ -30,7 +30,7 @@ static void
     SWAP_IFCOL(g->order,m,n);
     lda = NDL_STEP(lp,0) / sizeof(dtype);
 
-    printf("order=%d m=%d n=%d k=%d lda=%d \n",g->order,m,n,k,lda);
+    //printf("order=%d m=%d n=%d k=%d lda=%d \n",g->order,m,n,k,lda);
 
     *info = (*func_p)(g->order, m, n, k, a, lda, tau);
     CHECK_ERROR(*info);


### PR DESCRIPTION
There is a `printf` function for debugging in the `gqr` template called in `Numo::Linalg.qr`.

```ruby
> Numo::Linalg.qr(Numo::DFloat.new(4, 2).rand)
order=101 m=4 n=4 k=2 lda=4
=> [Numo::DFloat#shape=[4,4]
[[-0.0636761, 0.505476, -0.365994, -0.778773],
 [-0.819548, -0.49264, 0.0679184, -0.284665],
 [-0.119652, 0.406772, 0.893776, -0.146235],
 [-0.55675, 0.579945, -0.250201, 0.53953]], Numo::DFloat#shape=[4,2]
[[-0.969822, -0.640462],
 [0, 0.65737],
 [0, 0],
 [0, 0]]]
> Numo::Linalg::Lapack.call(:orgqr, Numo::DFloat.new(4, 4).rand, Numo::DFloat.new(4, 4).rand)
order=101 m=4 n=4 k=4 lda=4
order=101 m=4 n=4 k=4 lda=4
order=101 m=4 n=4 k=4 lda=4
order=101 m=4 n=4 k=4 lda=4
```

 I commented out this printf to suppress the debug message.

```ruby
> Numo::Linalg.qr(Numo::DFloat.new(4, 2).rand)
=> [Numo::DFloat#shape=[4,4]
[[-0.0636761, 0.505476, -0.365994, -0.778773],
 [-0.819548, -0.49264, 0.0679184, -0.284665],
 [-0.119652, 0.406772, 0.893776, -0.146235],
 [-0.55675, 0.579945, -0.250201, 0.53953]], Numo::DFloat#shape=[4,2]
[[-0.969822, -0.640462],
 [0, 0.65737],
 [0, 0],
 [0, 0]]]
```
