### PR TITLE
Fix bug in the dot method caused by dot product with complex vectors

### DIFF
--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -86,7 +86,8 @@ module Numo; module Linalg
     when 1
       case b.ndim
       when 1
-        Blas.call(:dot, a, b)
+        func = blas_char(a, b) =~ /c|z/ ? :dotu : :dot
+        Blas.call(func, a, b)
       else
         Blas.call(:gemv, b, a, trans:'t')
       end


### PR DESCRIPTION
I found a bug on the `Numo::Linalg.dot` method. The bug occurs when performing dot product with complex vectors.

```ruby
> require 'numo/narray'
=> true
> x=Numo::DComplex.new(3).rand
=> Numo::DComplex#shape=[3]
[0.0617545+0.373067i, 0.794815+0.201042i, 0.116041+0.344032i]
> y=Numo::DComplex.new(3).rand
=> Numo::DComplex#shape=[3]
[0.539948+0.737815i, 0.165089+0.0508827i, 0.108065+0.0687079i]
> x.dot(y)
=> (-0.13202269608393907+0.365782771213446i)
>
*
> require 'numo/linalg/autoloader'
=> true
> x.dot(y)
NoMethodError: undefined method `zdot' for Numo::Linalg::Blas:Module
…
```

The BLAS function that performs dot product of complex vectors are `zdotu` and `cdotu`. Thus, I fixed those functions to be called when given a complex vector to the dot method.

```ruby
> require 'numo/linalg/autoloader'
=> true
> x=Numo::DComplex.new(3).rand
=> Numo::DComplex#shape=[3]
[0.0617545+0.373067i, 0.794815+0.201042i, 0.116041+0.344032i]
> y=Numo::DComplex.new(3).rand
=> Numo::DComplex#shape=[3]
[0.539948+0.737815i, 0.165089+0.0508827i, 0.108065+0.0687079i]
> x.dot(y)
=> (-0.13202269608393907+0.36578277121344605i)
```