### PR TITLE
[Propose][Bugfix] Remove the disabled driver and uplo options from the LU factorization methods

### DIFF
--- a/spec/linalg/function/inv_spec.rb
+++ b/spec/linalg/function/inv_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Numo::Linalg do
     let(:m) { 5 }
     let(:mat_a) { rand_square_real_mat(m) }
     let(:mat_b) { rand_square_complex_mat(m) }
+    let(:mat_s) { rand_symmetric_mat(m) }
+    let(:mat_h) { rand_hermitian_mat(m) }
 
     it 'raises ArgumentError given a invalid driver option' do
       expect { described_class.inv(mat_a, driver: 'foo') }.to raise_error(ArgumentError)
@@ -22,6 +24,16 @@ RSpec.describe Numo::Linalg do
       expect((inv_mat_b.dot(mat_b) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
     end
 
+    it 'calculates the inverse of a symmetric matrix solving linear equation' do
+      inv_mat_s = described_class.inv(mat_s, driver: 'sysv')
+      expect((inv_mat_s.dot(mat_s) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the inverse of a hermitian matrix solving linear equation' do
+      inv_mat_h = described_class.inv(mat_h, driver: 'hesv')
+      expect((inv_mat_h.dot(mat_h) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
+    end
+
     it 'calculates the inverse of a square real matrix using the LU factorization' do
       inv_mat_a = described_class.inv(mat_a, driver: 'getrf')
       expect((inv_mat_a.dot(mat_a) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
@@ -30,6 +42,16 @@ RSpec.describe Numo::Linalg do
     it 'calculates the inverse of a square complex matrix using the LU factorization' do
       inv_mat_b = described_class.inv(mat_b, driver: 'getrf')
       expect((inv_mat_b.dot(mat_b) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the inverse of a symmetric matrix using the LU factorization' do
+      inv_mat_s = described_class.inv(mat_s, driver: 'sytrf')
+      expect((inv_mat_s.dot(mat_s) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the inverse of a hermitian matrix using the LU factorization' do
+      inv_mat_h = described_class.inv(mat_h, driver: 'hetrf')
+      expect((inv_mat_h.dot(mat_h) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL
     end
   end
 end

--- a/spec/linalg/function/lu_fact_spec.rb
+++ b/spec/linalg/function/lu_fact_spec.rb
@@ -10,25 +10,14 @@ RSpec.describe Numo::Linalg do
     let(:mat_b) { rand_rect_complex_mat(m, n) }
 
     def permutation_mat(ipiv)
-      mat_p = Numo::DFloat.eye(m)
-      (ipiv - 1).to_a.each_with_index.select do |a, b|
-        unless a - b == 0
-          tmp = mat_p[b, true].dup
-          mat_p[b, true] = mat_p[a, true]
-          mat_p[a, true] = tmp
-        end
+      Numo::DFloat.eye(m).tap do |mat|
+        ipiv.to_a.each_with_index { |a, b| mat[[a - 1, b], true] = mat[[b, a - 1], true].dup }
       end
-      mat_p
-    end
-
-    it 'raises ArgumentError given a invalid mode option' do
-      expect { described_class.lu_fact(Numo::DFloat.new(2, 4).rand, mode: 'foo') }.to raise_error(ArgumentError)
     end
 
     it 'calculates the LU factorization of a rectangular real matrix' do
       lu, ipiv = described_class.lu_fact(mat_a)
-      mat_l = lu.tril
-      mat_l[mat_l.diag_indices(0)] = 1.0
+      mat_l = lu.tril.tap { |mat| mat[mat.diag_indices(0)] = 1.0 }
       mat_u = lu.triu[0...n, 0...n]
       mat_p = permutation_mat(ipiv)
       expect((mat_p.dot(mat_a) - mat_l.dot(mat_u)).abs.max).to be < ERR_TOL
@@ -36,8 +25,7 @@ RSpec.describe Numo::Linalg do
 
     it 'calculates the LU factorization of a rectangular complex matrix' do
       lu, ipiv = described_class.lu_fact(mat_b)
-      mat_l = lu.tril
-      mat_l[mat_l.diag_indices(0)] = 1.0
+      mat_l = lu.tril.tap { |mat| mat[mat.diag_indices(0)] = 1.0 }
       mat_u = lu.triu[0...n, 0...n]
       mat_p = permutation_mat(ipiv)
       expect((mat_p.dot(mat_b) - mat_l.dot(mat_u)).abs.max).to be < ERR_TOL

--- a/spec/linalg/function/lu_inv_spec.rb
+++ b/spec/linalg/function/lu_inv_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Numo::Linalg do
     let(:mat_a) { rand_square_real_mat(m) }
     let(:mat_b) { rand_square_complex_mat(m) }
 
-    it 'raises ArgumentError given a invalid driver option' do
-      expect { described_class.inv(mat_a, driver: 'foo') }.to raise_error(ArgumentError)
-    end
-
     it 'calculates the inverse of a square real matrix' do
       inv_mat_a = described_class.inv(mat_a)
       expect((inv_mat_a.dot(mat_a) - Numo::DFloat.eye(m)).abs.max).to be < ERR_TOL

--- a/spec/linalg/function/lu_solve_spec.rb
+++ b/spec/linalg/function/lu_solve_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe Numo::Linalg do
     let(:mat_d) { rand_rect_complex_mat(m, n) }
     let(:vec_d) { rand_complex_vec(m) }
 
-    it 'raises ArgumentError given a invalid driver option' do
-      expect { described_class.lu_solve(nil, nil, nil, driver: 'foo') }.to raise_error(ArgumentError)
-    end
-
     it 'solves the linear equation A x = b with a square real matrix A' do
       lu, ipiv = described_class.lu_fact(mat_a)
       vec_x = described_class.lu_solve(lu, ipiv, vec_b)


### PR DESCRIPTION
I would like to propose removing the driver and uplo options from the LU factorization methods since these options do not work.

```ruby
> require 'numo/linalg/autoloader'
> a = Numo::DFloat.new(3, 3).rand
> a = 0.5 * (a + a.transpose)
> Numo::Linalg.lu_fact(a, driver: 'sym')
NoMethodError: undefined method `dsymtrf' for Numo::Linalg::Lapack:Module
...

```

I think that the method attempts to call the [sytrf](https://software.intel.com/en-us/mkl-developer-reference-c-sytrf) and [hetrf](https://software.intel.com/en-us/mkl-developer-reference-c-hetrf) functions in LAPACK. However, these functions perform not the LU factorization but the Bunch-Kaufman (or LDLt) factorization. In addition, the `getrf` functions, that are called when driver option is 'gen', can perform LU decomposition for symmetric matrix or Hermitian matrix. 

From the above, I think that it is better to remove the driver option and associated uplo option from the LU factorization methods.