### PR TITLE
Fix bug in the solve method when given a driver option other than gen

### DIFF
--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -777,7 +777,7 @@ module Numo; module Linalg
       # returns lu, x, ipiv, info
       Lapack.call(:gesv, a, b)[1]
     when /^(sym?|her?|pos?)(sv)?$/i
-      func = driver[0..2].downcase+"sv"
+      func = driver[0..1].downcase+"sv"
       Lapack.call(func, a, b, uplo:uplo)[1]
     else
       raise ArgumentError, "invalid driver: #{driver}"

--- a/spec/linalg/function/solve_spec.rb
+++ b/spec/linalg/function/solve_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Numo::Linalg do
     let(:mat_c) { rand_square_complex_mat(m) }
     let(:mat_d) { rand_rect_complex_mat(m, n) }
     let(:vec_d) { rand_complex_vec(m) }
+    let(:mat_s) { rand_symmetric_mat(m) }
+    let(:mat_h) { rand_hermitian_mat(m) }
+    let(:mat_p) { mat_s.dot(mat_s.transpose) }
+    let(:mat_q) { mat_h.dot(mat_h.transpose.conj) }
 
     it 'raises ArgumentError given a invalid driver option' do
       expect { described_class.solve(mat_a, vec_b, driver: 'foo') }.to raise_error(ArgumentError)
@@ -45,6 +49,50 @@ RSpec.describe Numo::Linalg do
       expect((mat_c.dot(vec_x) - vec_d).abs.max).to be < ERR_TOL
       mat_x = described_class.solve(mat_c, mat_d)
       expect((mat_c.dot(mat_x) - mat_d).abs.max).to be < ERR_TOL
+    end
+
+    it 'solves the linear equation A x = b with a symmetric matrix A' do
+      vec_x = described_class.solve(mat_s, vec_b, driver: 'sym')
+      expect((mat_s.dot(vec_x) - vec_b).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_s, mat_b, driver: 'sym')
+      expect((mat_s.dot(mat_x) - mat_b).abs.max).to be < ERR_TOL
+      vec_x = described_class.solve(mat_s, vec_d, driver: 'sym')
+      expect((mat_s.dot(vec_x) - vec_d).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_s, mat_d, driver: 'sym')
+      expect((mat_s.dot(mat_x) - mat_d).abs.max).to be < ERR_TOL
+    end
+
+    it 'solves the linear equation A x = b with a hermitian matrix A' do
+      vec_x = described_class.solve(mat_h, vec_b, driver: 'her')
+      expect((mat_h.dot(vec_x) - vec_b).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_h, mat_b, driver: 'her')
+      expect((mat_h.dot(mat_x) - mat_b).abs.max).to be < ERR_TOL
+      vec_x = described_class.solve(mat_h, vec_d, driver: 'her')
+      expect((mat_h.dot(vec_x) - vec_d).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_h, mat_d, driver: 'her')
+      expect((mat_h.dot(mat_x) - mat_d).abs.max).to be < ERR_TOL
+    end
+
+    it 'solves the linear equation A x = b with a symmetric positive-definite matrix A' do
+      vec_x = described_class.solve(mat_p, vec_b, driver: 'pos')
+      expect((mat_p.dot(vec_x) - vec_b).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_p, mat_b, driver: 'pos')
+      expect((mat_p.dot(mat_x) - mat_b).abs.max).to be < ERR_TOL
+      vec_x = described_class.solve(mat_p, vec_d, driver: 'pos')
+      expect((mat_p.dot(vec_x) - vec_d).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_p, mat_d, driver: 'pos')
+      expect((mat_p.dot(mat_x) - mat_d).abs.max).to be < ERR_TOL
+    end
+
+    it 'solves the linear equation A x = b with a hermitian positive-definite matrix A' do
+      vec_x = described_class.solve(mat_q, vec_b, driver: 'pos')
+      expect((mat_q.dot(vec_x) - vec_b).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_q, mat_b, driver: 'pos')
+      expect((mat_q.dot(mat_x) - mat_b).abs.max).to be < ERR_TOL
+      vec_x = described_class.solve(mat_q, vec_d, driver: 'pos')
+      expect((mat_q.dot(vec_x) - vec_d).abs.max).to be < ERR_TOL
+      mat_x = described_class.solve(mat_q, mat_d, driver: 'pos')
+      expect((mat_q.dot(mat_x) - mat_d).abs.max).to be < ERR_TOL
     end
   end
 end


### PR DESCRIPTION
I found a bug in the `solve` method. The solve method raises `NoMethodError` when given a driver option other than `'gen'` such as `'sym'`, `'her'`, and `'pos'`.

```ruby
> require 'numo/linalg/autoloader'
> a = Numo::DFloat.new(3, 3).rand
> b = Numo::DFloat.new(3).rand
> a = 0.5 * (a + a.transpose)
=> Numo::DFloat#shape=[3,3]
[[0.0617545, 0.287054, 0.667382],
 [0.287054, 0.116041, 0.540924],
 [0.667382, 0.540924, 0.165089]]
> Numo::Linalg.solve(a, b, driver: 'sym')
NoMethodError: undefined method `dsymsv' for Numo::Linalg::Lapack:Module
...
```

This bug occurs because of an inccorect range of the number of characters to cut out from the driver option. In fact, the solve method tries to call the [sysv](https://software.intel.com/en-us/mkl-developer-reference-c-sysv) functions in LAPACK. I fixed this bug and confirmed the solve method works correctly.

```ruby
> x = Numo::Linalg.solve(a, b, driver: 'sym')
=> Numo::DFloat#shape=[3]
[0.202466, -0.161535, 0.126987]
> (a.dot(x) - b).abs.max
=> 6.938893903907228e-18
```