### PR TITLE
[Propose] Add new method for LU decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This desgin allows you to change backend libraries without re-compiling.
 * Matrix and vector products
     * dot, matmul
 * Decomposition
-    * lu\_fact, lu\_inv, lu\_solve, cho\_fact, cho\_inv, cho\_solve
+    * lu, lu\_fact, lu\_inv, lu\_solve, cho\_fact, cho\_inv, cho\_solve,
       qr, svd, svdvals
 * Matrix eigenvalues
     * eig, eigh, eigvals, eigvalsh

--- a/spec/linalg/function/lu_spec.rb
+++ b/spec/linalg/function/lu_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg do
+  describe 'lu' do
+    let(:m) { 5 }
+    let(:n) { 3 }
+    let(:mat_a) { rand_rect_real_mat(m, n) }
+    let(:mat_b) { rand_rect_real_mat(n, m) }
+    let(:mat_c) { rand_rect_complex_mat(m, n) }
+    let(:mat_d) { rand_rect_complex_mat(n, m) }
+
+    it 'raises ShapeError given a vector' do
+      expect { described_class.lu(Numo::DFloat.new(3).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'calculates the LU factorization of a rectangular real matrix' do
+      mat_p, mat_l, mat_u = described_class.lu(mat_a)
+      expect((mat_a - mat_p.dot(mat_l.dot(mat_u))).abs.max).to be < ERR_TOL
+      mat_p, mat_l, mat_u = described_class.lu(mat_b)
+      expect((mat_b - mat_p.dot(mat_l.dot(mat_u))).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the LU factorization of a rectangular real matrix including permutation of L' do
+      mat_l, mat_u = described_class.lu(mat_a, permute_l: true)
+      expect((mat_a - mat_l.dot(mat_u)).abs.max).to be < ERR_TOL
+      mat_l, mat_u = described_class.lu(mat_b, permute_l: true)
+      expect((mat_b - mat_l.dot(mat_u)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the LU factorization of a rectangular complex matrix' do
+      mat_p, mat_l, mat_u = described_class.lu(mat_c)
+      expect((mat_c - mat_p.dot(mat_l.dot(mat_u))).abs.max).to be < ERR_TOL
+      mat_p, mat_l, mat_u = described_class.lu(mat_d)
+      expect((mat_d - mat_p.dot(mat_l.dot(mat_u))).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the LU factorization of a rectangular complex matrix including permutation of L' do
+      mat_l, mat_u = described_class.lu(mat_c, permute_l: true)
+      expect((mat_c - mat_l.dot(mat_u)).abs.max).to be < ERR_TOL
+      mat_l, mat_u = described_class.lu(mat_d, permute_l: true)
+      expect((mat_d - mat_l.dot(mat_u)).abs.max).to be < ERR_TOL
+    end
+  end
+end


### PR DESCRIPTION
I would like to add new method for LU decomposition like  [scipy.linalg.lu](https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.linalg.lu.html). The already existing `lu_fact` method returns the factor and permutation matrices in a form different from the form of LU decomposition. In contrast, the `lu` method in this PR returns three matrices according to the form of LU decomposition that is A = P * L * U:

```ruby
> a = Numo::DFloat.new(4, 3).rand
=> Numo::DFloat#shape=[4,3]
[[0.0617545, 0.373067, 0.794815],
 [0.201042, 0.116041, 0.344032],
 [0.539948, 0.737815, 0.165089],
 [0.0508827, 0.108065, 0.0687079]]

> p, l, u = Numo::Linalg.lu(a)
=> [Numo::DFloat#shape=[4,4]
[[0, 1, 0, 0],
 [0, 0, 1, 0],
 [1, 0, 0, 0],
 [0, 0, 0, 1]], Numo::DFloat(view)#shape=[4,3]
[[1, 0, 0],
 [0.114371, 1, 0],
 [0.372336, -0.549651, 1],
 [0.0942363, 0.133488, -0.0711185]], Numo::DFloat(view)#shape=[3,3]
[[0.539948, 0.737815, 0.165089],
 [0, 0.288682, 0.775934],
 [0, 0, 0.709057]]]
 
> p.dot(l.dot(u))
=> Numo::DFloat#shape=[4,3]
[[0.0617545, 0.373067, 0.794815],
 [0.201042, 0.116041, 0.344032],
 [0.539948, 0.737815, 0.165089],
 [0.0508827, 0.108065, 0.0687079]]

> (a - p.dot(l.dot(u))).abs.max
=> 5.551115123125783e-17
```