### PR TITLE
[Propose] Add new method for Cholesky factorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This desgin allows you to change backend libraries without re-compiling.
 * Matrix and vector products
     * dot, matmul
 * Decomposition
-    * lu, lu\_fact, lu\_inv, lu\_solve, cho\_fact, cho\_inv, cho\_solve,
+    * lu, lu\_fact, lu\_inv, lu\_solve, cholesky, cho\_fact, cho\_inv, cho\_solve,
       qr, svd, svdvals
 * Matrix eigenvalues
     * eig, eigh, eigvals, eigvalsh

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -397,6 +397,31 @@ module Numo; module Linalg
     Lapack.call(:getrs, lu, ipiv, b, trans:trans)[0]
   end
 
+  # Computes the Cholesky factorization of a symmetric/Hermitian
+  # positive definite matrix A. The factorization has the form
+  #
+  #     A = U**H * U,  if UPLO = 'U', or
+  #     A = L  * L**H,  if UPLO = 'L',
+  #
+  # where U is an upper triangular matrix and L is a lower triangular matrix.
+  # @param a [Numo::NArray] n-by-n symmetric matrix A (>= 2-dimensinal NArray)
+  # @param uplo [String or Symbol] optional, default='U'. Access upper
+  #   or ('U') lower ('L') triangle.
+  # @return [Numo::NArray] The factor U or L.
+
+  def cholesky(a, uplo: 'U')
+    raise NArray::ShapeError, '2-d array is required' if a.ndim < 2
+    raise NArray::ShapeError, 'matrix a is not square matrix' if a.shape[0] != a.shape[1]
+    factor = Lapack.call(:potrf, a, uplo: uplo)[0]
+    if uplo == 'U'
+      factor.triu
+    else
+      # TODO: Use the tril method if the verision of Numo::NArray
+      #       in the runtime dependency list becomes 0.9.1.3 or higher.
+      m, = a.shape
+      factor * Numo::DFloat.ones(m, m).triu.transpose
+    end
+  end
 
   # Computes the Cholesky factorization of a symmetric/Hermitian
   # positive definite matrix A. The factorization has the form
@@ -404,16 +429,16 @@ module Numo; module Linalg
   #     A = U**H * U,  if UPLO = 'U', or
   #     A = L  * L**H,  if UPLO = 'L',
   #
-  # where U is an upper triangular matrix and L is lower triangular
+  # where U is an upper triangular matrix and L is a lower triangular matrix.
   # @param a [Numo::NArray] n-by-n symmetric matrix A (>= 2-dimensinal NArray)
   # @param uplo [String or Symbol] optional, default='U'. Access upper
   #   or ('U') lower ('L') triangle.
-  # @return [Numo::NArray] the factor U or L.
+  # @return [Numo::NArray] The matrix which has the Cholesky factor in upper or lower triangular part.
+  #   Remain part consists of random values.
 
   def cho_fact(a, uplo:'U')
     Lapack.call(:potrf, a, uplo:uplo)[0]
   end
-  #alias cholesky cho_fact
 
   # Computes the inverse of a symmetric/Hermitian
   # positive definite matrix A using the Cholesky factorization

--- a/spec/linalg/function/cholesky_spec.rb
+++ b/spec/linalg/function/cholesky_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg do
+  describe 'cholesky' do
+    let(:m) { 5 }
+    let(:mat_a) do
+      a = rand_symmetric_mat(m)
+      a.dot(a.transpose)
+    end
+    let(:mat_b) do
+      b = rand_hermitian_mat(m)
+      b.dot(b.transpose.conj)
+    end
+
+    it 'raises ShapeError given a vector' do
+      expect { described_class.cholesky(Numo::DFloat.new(3).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'raises ShapeError given a rectangular matrix' do
+      expect { described_class.cholesky(Numo::DFloat.new(2, 4).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'raises ArgumentError given an invalid uplo option' do
+      expect { described_class.cholesky(mat_a, uplo: 'A') }.to raise_error(ArgumentError)
+    end
+
+    it 'calculates the cholesky factorization of a symmetric positive-definite matrix' do
+      mat_u = described_class.cholesky(mat_a, uplo: 'U')
+      expect((mat_a - mat_u.transpose.dot(mat_u)).abs.max).to be < ERR_TOL
+      mat_l = described_class.cholesky(mat_a, uplo: 'L')
+      expect((mat_a - mat_l.dot(mat_l.transpose)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates the cholesky factorization of a hermitian positive-definite matrix' do
+      mat_u = described_class.cholesky(mat_b, uplo: 'U')
+      expect((mat_b - mat_u.transpose.conj.dot(mat_u)).abs.max).to be < ERR_TOL
+      mat_l = described_class.cholesky(mat_b, uplo: 'L')
+      expect((mat_b - mat_l.dot(mat_l.transpose.conj)).abs.max).to be < ERR_TOL
+    end
+  end
+end


### PR DESCRIPTION
I would like to add new method for Cholesky factorization like [scipy.linalg.cholesky](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.cholesky.html#scipy.linalg.cholesky). 

[Cholesky factorization](http://mathworld.wolfram.com/CholeskyDecomposition.html) decomposes a symmetric/Hermitian positive define matrix into the product of an upper / lower triangular matrix such as A = U^T * U. The already existing `cho_fact` method returns the matrix which has the Cholesky factor in upper / lower triangular part. However, the remain part consists of random values. Thus, it is difficult to reconstruct the original matrix using the returned matrix from the cho_fact method.

```ruby
> a = Numo::DFloat.new(3,3).rand
> a = a.dot(a.transpose)
=> Numo::DFloat#shape=[3,3]
[[1.22905, 0.817261, 0.924107],
 [0.817261, 0.881999, 0.448001],
 [0.924107, 0.448001, 0.830497]]

> u = Numo::Linalg.cho_fact(a)
=> Numo::DFloat#shape=[3,3]
[[1.10862, 0.737185, 0.833562],
 [0.817261, 0.581856, -0.286134],
 [0.924107, 0.448001, 0.231946]]
irb(main):031:0> u.transpose.dot(u)
=> Numo::DFloat#shape=[3,3]
[[2.75094, 1.70679, 0.904603],
 [1.70679, 1.0827, 0.551913],
 [0.904603, 0.551913, 0.830497]]
irb(main):032:0>
```

In contrast, the `cholesky` method in this PR returns the upper / lower triangular matrix consits of Cholesky factor. The original matrix can be reconstructed by the product of the matrix returned by the `cholesky` method.

```ruby
> a
=> Numo::DFloat#shape=[3,3]
[[1.22905, 0.817261, 0.924107],
 [0.817261, 0.881999, 0.448001],
 [0.924107, 0.448001, 0.830497]]

> u = Numo::Linalg.cholesky(a)
=> Numo::DFloat#shape=[3,3]
[[1.10862, 0.737185, 0.833562],
 [0, 0.581856, -0.286134],
 [0, 0, 0.231946]]
> u.transpose.dot(u)
=> Numo::DFloat#shape=[3,3]
[[1.22905, 0.817261, 0.924107],
 [0.817261, 0.881999, 0.448001],
 [0.924107, 0.448001, 0.830497]]
```