### PR TITLE
[Propose] Add new method for Bunch-Kaufman factorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This desgin allows you to change backend libraries without re-compiling.
 * Matrix and vector products
     * dot, matmul
 * Decomposition
-    * lu, lu\_fact, lu\_inv, lu\_solve, cholesky, cho\_fact, cho\_inv, cho\_solve,
+    * lu, lu\_fact, lu\_inv, lu\_solve, ldl, cholesky, cho\_fact, cho\_inv, cho\_solve,
       qr, svd, svdvals
 * Matrix eigenvalues
     * eig, eigh, eigvals, eigvalsh

--- a/spec/linalg/function/ldl_spec.rb
+++ b/spec/linalg/function/ldl_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg do
+  describe 'ldl' do
+    let(:m) { 5 }
+    let(:mat_s) { rand_symmetric_mat(m) }
+    let(:mat_c) { rand_symmetric_mat(m) + Complex::I * rand_symmetric_mat(m) }
+    let(:mat_h) { rand_hermitian_mat(m) }
+
+    it 'raises ShapeError given a vector' do
+      expect { described_class.ldl(Numo::DFloat.new(3).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'raises ShapeError given a rectangular matrix' do
+      expect { described_class.ldl(Numo::DFloat.new(2, 4).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'raises ArgumentError given an invalid uplo option' do
+      expect { described_class.ldl(mat_s, uplo: 'A') }.to raise_error(ArgumentError)
+    end
+
+    it 'calculates the LDLt or Bunch-Kaufman factorization of a symmetric real matrix' do
+      mat_u, mat_d, perm = described_class.ldl(mat_s, uplo: 'U')
+      expect((mat_s - mat_u.dot(mat_d.dot(mat_u.transpose))).abs.max).to be < ERR_TOL
+      expect(mat_u[perm, true].tril(-1)).to eq(Numo::DFloat.zeros(m, m))
+      mat_l, mat_d, perm = described_class.ldl(mat_s, uplo: 'L')
+      expect((mat_s - mat_l.dot(mat_d.dot(mat_l.transpose))).abs.max).to be < ERR_TOL
+      expect(mat_l[perm, true].triu(1)).to eq(Numo::DFloat.zeros(m, m))
+    end
+
+    it 'calculates the LDLt or Bunch-Kaufman factorization of a symmetric complex matrix' do
+      mat_u, mat_d, perm = described_class.ldl(mat_c, uplo: 'U', hermitian: false)
+      expect((mat_c - mat_u.dot(mat_d.dot(mat_u.transpose))).abs.max).to be < ERR_TOL
+      expect(mat_u[perm, true].tril(-1)).to eq(Numo::DComplex.zeros(m, m))
+      mat_l, mat_d, perm = described_class.ldl(mat_c, uplo: 'L', hermitian: false)
+      expect((mat_c - mat_l.dot(mat_d.dot(mat_l.transpose))).abs.max).to be < ERR_TOL
+      expect(mat_l[perm, true].triu(1)).to eq(Numo::DComplex.zeros(m, m))
+    end
+
+    it 'calculates the LDLt or Bunch-Kaufman factorization of a hermitian matrix' do
+      mat_u, mat_d, perm = described_class.ldl(mat_h, uplo: 'U')
+      expect((mat_h - mat_u.dot(mat_d.dot(mat_u.transpose.conj))).abs.max).to be < ERR_TOL
+      expect(mat_u[perm, true].tril(-1)).to eq(Numo::DComplex.zeros(m, m))
+      mat_l, mat_d, perm = described_class.ldl(mat_h, uplo: 'L')
+      expect((mat_h - mat_l.dot(mat_d.dot(mat_l.transpose.conj))).abs.max).to be < ERR_TOL
+      expect(mat_l[perm, true].triu(1)).to eq(Numo::DComplex.zeros(m, m))
+    end
+  end
+end


### PR DESCRIPTION
I would like to add new method for LDLt or Bunch-Kaufman factorization like [scipy.linalg.ldl](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.ldl.html) method. Bunch-Kaufman factorization decomposes a symmetric/Hermitian matrix into the product of an upper / lower triangular matrix and block diagonal matrix such as A = U * D * U^T. 

```ruby
> a=Numo::DFloat.new(3,3).rand
> a=0.5*(a+a.transpose)
=> Numo::DFloat#shape=[3,3]
[[0.0617545, 0.287054, 0.667382],
 [0.287054, 0.116041, 0.540924],
 [0.667382, 0.540924, 0.165089]]
> u,d,p=Numo::Linalg.ldl(a)
> u.dot(d.dot(u.transpose))
=> Numo::DFloat#shape=[3,3]
[[0.0617545, 0.287054, 0.667382],
 [0.287054, 0.116041, 0.540924],
 [0.667382, 0.540924, 0.165089]]
> u[p,true]
=> Numo::DFloat(view)#shape=[3,3]
[[1, 0.720613, 0.36344],
 [0, 1, 0],
 [0, 0, 1]]
```