### PR TITLE
[Propose] Add methods for finding an orthogonal basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This desgin allows you to change backend libraries without re-compiling.
     * dot, matmul
 * Decomposition
     * lu, lu\_fact, lu\_inv, lu\_solve, ldl, cholesky, cho\_fact, cho\_inv, cho\_solve,
-      qr, svd, svdvals
+      qr, svd, svdvals, orth
 * Matrix eigenvalues
     * eig, eigh, eigvals, eigvalsh
 * Norms and other numbers

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This desgin allows you to change backend libraries without re-compiling.
     * dot, matmul
 * Decomposition
     * lu, lu\_fact, lu\_inv, lu\_solve, ldl, cholesky, cho\_fact, cho\_inv, cho\_solve,
-      qr, svd, svdvals, orth
+      qr, svd, svdvals, orth, null_space
 * Matrix eigenvalues
     * eig, eigh, eigvals, eigvalsh
 * Norms and other numbers

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -296,6 +296,23 @@ module Numo; module Linalg
     end
   end
 
+  # Computes an orthonormal basis for the range of matrix A.
+  #
+  # @param a [Numo::NArray] m-by-n matrix A (>= 2-dimensional NArray).
+  # @param rcond [Float] (optional)
+  #   rcond is used to determine the effective rank of A.
+  #   Singular values `s[i] <= rcond * s.max` are treated as zero.
+  #   If rcond < 0, machine precision is used instead.
+  # @return [Numo::NArray] The orthonormal basis for the range of matrix A.
+
+  def orth(a, rcond: -1)
+    raise NArray::ShapeError, '2-d array is required' if a.ndim < 2
+    s, u, = svd(a)
+    tol = s.max * (rcond.nil? || rcond < 0 ? a.class::EPSILON * a.shape.max : rcond)
+    k = (s > tol).count
+    u[true, 0...k]
+  end
+
   # Computes an LU factorization of a M-by-N matrix A
   # using partial pivoting with row interchanges.
   #

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -313,6 +313,25 @@ module Numo; module Linalg
     u[true, 0...k]
   end
 
+  # Computes an orthonormal basis for the null space of matrix A.
+  #
+  # @param a [Numo::NArray] m-by-n matrix A (>= 2-dimensional NArray).
+  # @param rcond [Float] (optional)
+  #   rcond is used to determine the effective rank of A.
+  #   Singular values `s[i] <= rcond * s.max` are treated as zero.
+  #   If rcond < 0, machine precision is used instead.
+  # @return [Numo::NArray] The orthonormal basis for the null space of matrix A.
+
+  def null_space(a, rcond: -1)
+    raise NArray::ShapeError, '2-d array is required' if a.ndim < 2
+    s, _u, vh = svd(a)
+    tol = s.max * (rcond.nil? || rcond < 0 ? a.class::EPSILON * a.shape.max : rcond)
+    k = (s > tol).count
+    return a.class.new if k == vh.shape[0]
+    r = vh[k..-1, true].transpose.dup
+    blas_char(vh) =~ /c|z/ ? r.conj : r
+  end
+
   # Computes an LU factorization of a M-by-N matrix A
   # using partial pivoting with row interchanges.
   #

--- a/spec/linalg/function/null_space_spec.rb
+++ b/spec/linalg/function/null_space_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg do
+  describe 'null_space' do
+    let(:r) { 2 }
+    let(:m) { 6 }
+    let(:n) { 4 }
+    let(:mat_a) { rand_rect_real_mat(m, r).dot(rand_rect_real_mat(r, n)) }
+    let(:mat_b) { rand_rect_complex_mat(m, r).dot(rand_rect_complex_mat(r, n)) }
+    let(:mat_c) { mat_a + 1.0e-6 * Numo::DFloat.new(m, n).rand }
+
+    it 'raises ShapeError given a vector' do
+      expect { described_class.lu(Numo::DFloat.new(3).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'calculates an orthonormal basis for the null space of a real matrix' do
+      basis = described_class.null_space(mat_a)
+      expect(basis.shape[0]).to eq(n)
+      expect(basis.shape[1]).to eq(r)
+      expect((basis.transpose.dot(basis) - Numo::DFloat.eye(r)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates an orthonormal basis for the null space of a complex matrix' do
+      basis = described_class.null_space(mat_b)
+      expect(basis.shape[0]).to eq(n)
+      expect(basis.shape[1]).to eq(r)
+      expect((basis.transpose.conj.dot(basis) - Numo::DFloat.eye(r)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates an orthonormal basis according to the given rcond value' do
+      basis = described_class.null_space(mat_c, rcond: 1.0e-4)
+      expect(basis.shape[0]).to eq(n)
+      expect(basis.shape[1]).to eq(r)
+      expect((basis.transpose.dot(basis) - Numo::DFloat.eye(r)).abs.max).to be < ERR_TOL
+      basis = described_class.null_space(mat_c, rcond: 1.0e-8)
+      expect(basis.shape).to be_empty
+    end
+  end
+end

--- a/spec/linalg/function/orth_spec.rb
+++ b/spec/linalg/function/orth_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg do
+  describe 'orth' do
+    let(:r) { 2 }
+    let(:m) { 6 }
+    let(:n) { 3 }
+    let(:mat_a) { rand_rect_real_mat(m, r).dot(rand_rect_real_mat(r, n)) }
+    let(:mat_b) { rand_rect_complex_mat(m, r).dot(rand_rect_complex_mat(r, n)) }
+    let(:mat_c) { mat_a + 1.0e-6 * Numo::DFloat.new(m, n).rand }
+
+    it 'raises ShapeError given a vector' do
+      expect { described_class.lu(Numo::DFloat.new(3).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'calculates an orthonormal basis for the range of a real matrix' do
+      basis = described_class.orth(mat_a)
+      expect(basis.shape[0]).to eq(m)
+      expect(basis.shape[1]).to eq(r)
+      expect((basis.transpose.dot(basis) - Numo::DFloat.eye(r)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates an orthonormal basis for the range of a complex matrix' do
+      basis = described_class.orth(mat_b)
+      expect(basis.shape[0]).to eq(m)
+      expect(basis.shape[1]).to eq(r)
+      expect((basis.transpose.conj.dot(basis) - Numo::DFloat.eye(r)).abs.max).to be < ERR_TOL
+    end
+
+    it 'calculates an orthonormal basis according to the given rcond value' do
+      basis = described_class.orth(mat_c, rcond: 1.0e-4)
+      expect(basis.shape[0]).to eq(m)
+      expect(basis.shape[1]).to eq(r)
+      expect((basis.transpose.dot(basis) - Numo::DFloat.eye(r)).abs.max).to be < ERR_TOL
+      basis = described_class.orth(mat_c, rcond: 1.0e-8)
+      expect(basis.shape[0]).to eq(m)
+      expect(basis.shape[1]).to eq(n)
+      expect((basis.transpose.dot(basis) - Numo::DFloat.eye(n)).abs.max).to be < ERR_TOL
+    end
+  end
+end


### PR DESCRIPTION
I would like to add new methods for finding an orthogonal basis like [scipy.linalg.orth](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.orth.html#scipy.linalg.orth) and [scipy.linalg.null_space](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.null_space.html#scipy.linalg.null_space) methods.

```ruby
> a = Numo::DFloat[[2, 0, 0], [0, 5, 0]]
=> Numo::DFloat#shape=[2,3]
[[2, 0, 0],
 [0, 5, 0]]
> Numo::Linalg.orth(a)
=> Numo::DFloat(view)#shape=[2,2]
[[0, 1],
 [1, 0]]
> Numo::Linalg.orth(a.transpose)
=> Numo::DFloat(view)#shape=[3,2]
[[0, 1],
 [1, 0],
 [0, 0]]
```

```ruby
> b = Numo::DFloat.new(3, 5).rand
> z = Numo::Linalg.null_space(b)
> z.shape
=> [5, 2]
> b.dot(z)
=> Numo::DFloat#shape=[3,2]
[[1.92144e-17, -1.90014e-17],
 [6.35517e-17, -2.31759e-17],
 [4.25885e-17, 1.67474e-17]]
> z.transpose.dot(z)
=> Numo::DFloat#shape=[2,2]
[[1, -4.2071e-17],
 [-4.2071e-17, 1]]
```