### PR TITLE
Added contiguous check and fortran_contiguous check to dot method.

### DIFF
--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -92,7 +92,7 @@ module Numo; module Linalg
         if b.contiguous?
           trans = 't'
         else
-          if b.transpose?
+          if b.f_contiguous?
             trans = 'n'
             b = b.transpose
           else
@@ -108,7 +108,7 @@ module Numo; module Linalg
         if a.contiguous?
           trans = 'n'
         else
-          if a.transpose?
+          if a.f_contiguous?
             trans = 't'
             a = a.transpose
           else
@@ -121,7 +121,7 @@ module Numo; module Linalg
         if a.contiguous?
           transa = 'n'
         else
-          if a.transpose?
+          if a.f_contiguous?
             transa = 't'
             a = a.transpose
           else
@@ -132,7 +132,7 @@ module Numo; module Linalg
         if b.contiguous?
           transb = 'n'
         else
-          if b.transpose?
+          if b.f_contiguous?
             transb='t'
             b = b.transpose
           else

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -89,14 +89,58 @@ module Numo; module Linalg
         func = blas_char(a, b) =~ /c|z/ ? :dotu : :dot
         Blas.call(func, a, b)
       else
-        Blas.call(:gemv, b, a, trans:'t')
+        if b.contiguous?
+          trans = 't'
+        else
+          if b.transpose?
+            trans = 'n'
+            b = b.transpose
+          else
+            trans = 't'
+            b = b.dup
+          end
+        end
+        Blas.call(:gemv, b, a, trans:trans)
       end
     else
       case b.ndim
       when 1
-        Blas.call(:gemv, a, b)
+        if a.contiguous?
+          trans = 'n'
+        else
+          if a.transpose?
+            trans = 't'
+            a = a.transpose
+          else
+            trans = 'n'
+            a = a.dup
+          end
+        end
+        Blas.call(:gemv, a, b, trans:trans)
       else
-        Blas.call(:gemm, a, b)
+        if a.contiguous?
+          transa = 'n'
+        else
+          if a.transpose?
+            transa = 't'
+            a = a.transpose
+          else
+            transa = 'n'
+            a = a.dup
+          end
+        end
+        if b.contiguous?
+          transb = 'n'
+        else
+          if b.transpose?
+            transb='t'
+            b = b.transpose
+          else
+            transb='n'
+            b = b.dup
+          end
+        end
+        Blas.call(:gemm, a, b, transa:transa, transb:transb)
       end
     end
   end

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -92,7 +92,7 @@ module Numo; module Linalg
         if b.contiguous?
           trans = 't'
         else
-          if b.f_contiguous?
+          if b.fortran_contiguous?
             trans = 'n'
             b = b.transpose
           else
@@ -108,7 +108,7 @@ module Numo; module Linalg
         if a.contiguous?
           trans = 'n'
         else
-          if a.f_contiguous?
+          if a.fortran_contiguous?
             trans = 't'
             a = a.transpose
           else
@@ -121,7 +121,7 @@ module Numo; module Linalg
         if a.contiguous?
           transa = 'n'
         else
-          if a.f_contiguous?
+          if a.fortran_contiguous?
             transa = 't'
             a = a.transpose
           else
@@ -132,7 +132,7 @@ module Numo; module Linalg
         if b.contiguous?
           transb = 'n'
         else
-          if b.f_contiguous?
+          if b.fortran_contiguous?
             transb='t'
             b = b.transpose
           else


### PR DESCRIPTION
I wrote patch for improve the performance of the a.dot(b.transpose).
(See https://github.com/ruby-numo/numo-narray/issues/95 for details.)

This patch requires https://github.com/ruby-numo/numo-narray/pull/116 .

## Benchmarke code (numo-linalg 0.2.0 : this pull request version)

```
$ numo_linalg_fp32.yaml
contexts:
  - gems: { numo-linalg: 0.1.3 }
    require: false
    prelude: |
      require 'numo/linalg'
  - gems: { numo-linalg: 0.2.0 }
    require: false
    prelude: |
      require 'numo/linalg'

loop_count: 1000
prelude: |
  X = 1000
  Y = 784
  YY = Y + 1
  a = Numo::SFloat.new(X, Y).seq(0)
  b = Numo::SFloat.new(X, Y).seq(0).transpose
  c = b.dup
  d = Numo::SFloat.new(X, YY).seq(0)[true,1..-1]           # contiguous? => false, transpose? => false
  e = Numo::SFloat.new(X, YY).seq(0)[true,1..-1].transpose # contiguous? => false, transpose? => false
  f = e.dup
  sleep 30

benchmark:
  'a.dot(b.transpose)     : view     (contiguous? => false, transpose?  => true) ' : a.dot(b)
  'a.dot(b.transpose.dup) : not view (contiguous? => true)                       ' : a.dot(c)
  'a.dot(d.transpose)     : view     (contiguous? => false, transpose?  => false)' : a.dot(e)
  'a.dot(f.transpose.dup) : not view (contiguous? => true)                       ' : a.dot(f)
```

## Benchmarked Result (numo-linalg 0.2.0 : this pull request version)
```
$ ruby -v
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
$ gem install benchmark_driver
$ benchmark-driver  numo_linalg_fp32.yaml 
Calculating -------------------------------------
                                                                               numo-linalg 0.1.3  numo-linalg 0.2.0 
a.dot(b.transpose)     : view     (contiguous? => false, transpose?  => true)             40.131             60.995 i/s -      1.000k times in 24.918112s 16.394857s
a.dot(b.transpose.dup) : not view (contiguous? => true)                                   60.657             60.348 i/s -      1.000k times in 16.486182s 16.570423s
a.dot(d.transpose)     : view     (contiguous? => false, transpose?  => false)            37.098             51.162 i/s -      1.000k times in 26.955645s 19.545771s
a.dot(f.transpose.dup) : not view (contiguous? => true)                                   60.031             59.439 i/s -      1.000k times in 16.658179s 16.824028s

Comparison:
             a.dot(b.transpose)     : view     (contiguous? => false, transpose?  => true) 
                                                             numo-linalg 0.2.0:        61.0 i/s 
                                                             numo-linalg 0.1.3:        40.1 i/s - 1.52x  slower

             a.dot(b.transpose.dup) : not view (contiguous? => true)                       
                                                             numo-linalg 0.1.3:        60.7 i/s 
                                                             numo-linalg 0.2.0:        60.3 i/s - 1.01x  slower

             a.dot(d.transpose)     : view     (contiguous? => false, transpose?  => false)
                                                             numo-linalg 0.2.0:        51.2 i/s 
                                                             numo-linalg 0.1.3:        37.1 i/s - 1.38x  slower

             a.dot(f.transpose.dup) : not view (contiguous? => true)                       
                                                             numo-linalg 0.1.3:        60.0 i/s 
                                                             numo-linalg 0.2.0:        59.4 i/s - 1.01x  slower
```