### PR TITLE
Fix Travis CI config file to use the latest develop version of Numo::NArray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ before_install:
 
 install:
   - bundle install --jobs=3 --retry=3
+  - gem install specific_install
+  - gem specific_install https://github.com/ruby-numo/numo-narray
 
 script:
   - gem build numo-linalg.gemspec


### PR DESCRIPTION
Recently, the pull request using the latest develop version of Numo::NArray has been merged. The build test of Numo::Linalg fails because it uses the latest release version Numo::NArray. Therefore, I modified Travis CI config file to use the develop version of Numo::NArray.