### PR TITLE
[Conf] Fix runtime dependency version of Numo::NArray

### DIFF
--- a/numo-linalg.gemspec
+++ b/numo-linalg.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_runtime_dependency "numo-narray", ">= 0.9.0.7"
+  spec.add_runtime_dependency "numo-narray", ">= 0.9.1.4"
 end


### PR DESCRIPTION
Since Numo::Linalg is influenced by the `fortran_contiguous?` method added in version 0.9.1.4 of Numo::NArray, I would like to modify the runtime dependency version of Numo::NArray on gemspec file.

```bash
$ gem list | grep numo
numo-linalg (0.1.4)
numo-narray (0.9.1.3)
```

```irb
irb(main):001:0> require 'numo/linalg/autoloader'
=> true
irb(main):002:0> a=Numo::DFloat.new(3,2).rand
=> Numo::DFloat#shape=[3,2]
[[0.0617545, 0.373067],
 [0.794815, 0.201042],
 [0.116041, 0.344032]]
irb(main):003:0> a.dot(a.transpose)
Traceback (most recent call last):
        6: from /Users/atatsuma/.rbenv/versions/2.6.0/bin/irb:23:in `<main>'
        5: from /Users/atatsuma/.rbenv/versions/2.6.0/bin/irb:23:in `load'
        4: from /Users/atatsuma/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        3: from (irb):3
        2: from /Users/atatsuma/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/numo-narray-0.9.1.3/lib/numo/narray/extra.rb:1137:in `dot'
        1: from /Users/atatsuma/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/numo-linalg-0.1.4/lib/numo/linalg/function.rb:135:in `dot'
NoMethodError (undefined method `fortran_contiguous?' for #<Numo::DFloat:0x00007fcd888ec968>)
```