### PR TITLE
Add some directories to autoloader search path

### DIFF
--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -26,7 +26,8 @@ module Numo
         lapacke_dirs = ['/opt/lapack/lib', '/opt/lapack/lib64', '/opt/local/lib/lapack',
                         '/usr/local/opt/lapack/lib']
         opt_dirs =  ['/opt/local/lib', '/opt/local/lib64', '/opt/lib', '/opt/lib64']
-        base_dirs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64']
+        base_dirs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64',
+                     "/usr/lib/#{RbConfig::CONFIG['host_cpu']}-#{RbConfig::CONFIG['host_os']}"]
         base_dirs.unshift(*ENV['LD_LIBRARY_PATH'].split(':')) unless ENV['LD_LIBRARY_PATH'].nil?
 
         mkl_libs = find_mkl_libs([*base_dirs, *opt_dirs, *mkl_dirs])

--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -19,7 +19,8 @@ module Numo
       # @return [String] name of loaded backend library (mkl/openblas/lapack)
       def load_library
         mkl_dirs = ['/opt/intel/lib', '/opt/intel/lib64', '/opt/intel/mkl/lib', '/opt/intel/mkl/lib64']
-        openblas_dirs = ['/opt/openblas/lib', '/opt/openblas/lib64', '/usr/local/opt/openblas/lib']
+        openblas_dirs = ['/opt/OpenBLAS/lib', '/opt/OpenBLAS/lib64', '/opt/openblas/lib', '/opt/openblas/lib64',
+                         '/usr/local/opt/openblas/lib']
         atlas_dirs = ['/opt/atlas/lib', '/opt/atlas/lib64',
                       '/usr/lib/atlas', '/usr/lib64/atlas', '/usr/local/opt/atlas/lib']
         lapacke_dirs = ['/opt/lapack/lib', '/opt/lapack/lib64', '/opt/local/lib/lapack',


### PR DESCRIPTION
I would like to add the OpenBLAS default installation directory and multi-arch library directory of Debian family to the autoloader search path. In particular, the addition of the multi-arch directory is necessary to support recent versions of Debian / Ubuntu Linux.

The execution example in the environment where  OpenBLAS is built and installed from source and LAPACKE is installed from package manager is as follows:

```sh
$ cat /etc/debian_version
buster/sid
$ irb
irb(main):001:0> require 'numo/linalg/autoloader'
=> true
irb(main):002:0> Numo::Linalg::Autoloader.libs
=> ["/opt/OpenBLAS/lib/libopenblas.so", "/usr/lib/x86_64-linux-gnu/liblapacke.so"]
irb(main):003:0> Numo::Linalg.eigh(Numo::DFloat.new(2, 4).rand.cov)
=> [Numo::DFloat#shape=[2]
[0.0520039, 0.120047], Numo::DFloat#shape=[2, 2]
[[0.527075, -0.849819],
 [-0.849819, -0.527075]]
irb(main):004:0> ...
```

Reference: MultiArch on Linux https://www.pilotlogic.com/sitejoom/index.php/wiki?id=398