### PR TITLE
Add new method for matrix exponential

### DIFF
--- a/spec/linalg/function/expm_spec.rb
+++ b/spec/linalg/function/expm_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg do
+  describe 'det' do
+    it 'raises ShapeError given a rectangular matrix as matrix A' do
+      expect { described_class.expm(Numo::DFloat.new(2, 3).rand) }.to raise_error(Numo::NArray::ShapeError)
+    end
+
+    it 'calculates matrix exponential of matrix without full eigenvectors' do
+      e = Math.exp(1)
+      err = (described_class.expm(Numo::DFloat[[1, 2], [0, 1]]) - Numo::DFloat[[e, 2 * e], [0, e]]).abs.sum(1).max
+      expect(err).to be < 1e-6
+    end
+
+    it 'calculates matrix exponential for matrix with large norm' do
+      tmp = Numo::DFloat[[-0.0995741, 0.0746806], [-0.199148, 0.149361]]
+      err = (described_class.expm(Numo::DFloat[[-147, 72], [-192, 93]]) - tmp).abs.sum(1).max
+      expect(err).to be < 1e-6
+    end
+
+    it 'calculates matrix exponential for diagonal matrix' do
+      err = (described_class.expm(Numo::DFloat[2, 3].diag) - Numo::NMath.exp(Numo::DFloat[2, 3]).diag).abs.sum(1).max
+      expect(err).to be < 1e-6
+    end
+
+    it 'returns identity matrix when given zero matrix' do
+      expect(described_class.expm(Numo::DFloat.zeros([2, 2]))).to eq(Numo::DFloat.eye(2))
+    end
+
+    it 'returns complex matrix when given complex matrix' do
+      expect(described_class.expm(rand_rect_complex_mat(2, 2))).to be_a(Numo::DComplex)
+    end
+  end
+end


### PR DESCRIPTION
I have implemented the matrix exponential method for issue https://github.com/ruby-numo/numo-linalg/issues/32 . In scipy, it is implemented using the newer algorithm, but I implemented it using the basic pade approximation method[1].

Example of execution results like [scipy.linalg.expm](https://docs.scipy.org/doc/scipy-0.15.1/reference/generated/scipy.linalg.expm.html)

```ruby
> Numo::Linalg.expm(Numo::DFloat.zeros([2,2]))
=> Numo::DFloat#shape=[2,2]
[[1, 0],
 [0, 1]]
> Numo::Linalg.expm(Numo::DFloat[[1, 2], [-1, 3]] * Complex::I)
=> Numo::DComplex#shape=[2,2]
[[0.426459+1.89218i, -2.13721-0.978113i],
 [1.06861+0.489056i, -1.71076+0.914063i]]
```

[1] Gene H. Golub and Charles F. Van Loan, "Matrix Computations 4th Edition: Algorithm 9.3.1," JHU Press, 2013.