### PR TITLE
Support for keyword argument of Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - '2.4'
   - '2.5'
   - '2.6'
+  - '2.7'
 
 matrix:
   fast_finish:
@@ -28,9 +29,9 @@ before_install:
   - gem install --no-document bundler -v '~> 2.0'
 
 install:
-  - bundle install --jobs=3 --retry=3
   - gem install specific_install
   - gem specific_install https://github.com/ruby-numo/numo-narray
+  - bundle install --jobs=3 --retry=3
 
 script:
   - gem build numo-linalg.gemspec

--- a/lib/numo/linalg/function.rb
+++ b/lib/numo/linalg/function.rb
@@ -12,12 +12,19 @@ module Numo; module Linalg
     # defined from data-types of arguments.
     # @param [Symbol] func  function name without BLAS char.
     # @param args  arguments passed to Blas function.
+    # @param kwargs  keyword arguments passed to Blas function.
     # @example
     #      c = Numo::Linalg::Blas.call(:gemm, a, b)
-    def self.call(func,*args)
+    def self.call(func, *args, **kwargs)
       fn = (Linalg.blas_char(*args) + func.to_s).to_sym
       fn = FIXNAME[fn] || fn
-      send(fn,*args)
+      if kwargs.empty?
+        # This conditional branch is necessary to prevent ArgumentError
+        # that occurs in Ruby 2.6 or earlier.
+        send(fn, *args)
+      else
+        send(fn, *args, **kwargs)
+      end
     end
 
   end
@@ -34,12 +41,19 @@ module Numo; module Linalg
     # defined from data-types of arguments.
     # @param [Symbol,String] func  function name without BLAS char.
     # @param args  arguments passed to Lapack function.
+    # @param kwargs  keyword arguments passed to Lapack function.
     # @example
     #      s = Numo::Linalg::Lapack.call(:gesv, a)
-    def self.call(func,*args)
+    def self.call(func, *args, **kwargs)
       fn = (Linalg.blas_char(*args) + func.to_s).to_sym
       fn = FIXNAME[fn] || fn
-      send(fn,*args)
+      if kwargs.empty?
+        # This conditional branch is necessary to prevent ArgumentError
+        # that occurs in Ruby 2.6 or earlier.
+        send(fn, *args)
+      else
+        send(fn, *args, **kwargs)
+      end
     end
 
   end


### PR DESCRIPTION
Ruby 2.7 changes keyword argument assignment spec. In Numo::Linalg, the Blas.call and Lapack.call methods are affected by this change, so using Numo::Linalg will always occur a deprecation warning.

```sh
lib/numo/linalg/function.rb:20: warning: 
Using the last argument as keyword parameters is deprecated
```

This pull request addresses this issue.