### PR TITLE
Add rake-compiler to make build easier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,8 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Build and Install
+      - name: Build and test with Rake
         run: |
           gem install --no-document bundler
-          gem install --no-document specific_install
           bundle install --jobs 4 --retry 3
-          gem build numo-linalg.gemspec
-          gem install numo-linalg-*.gem
-      - name: Tests
-        run: rspec --color --format documentation --require spec_helper spec
+          bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,20 @@ end
 task :cleandoc do
   sh "rm -r yard .yardoc"
 end
+
+require 'rake/extensiontask'
+Rake::ExtensionTask.new 'numo/linalg/blas'
+Rake::ExtensionTask.new 'numo/linalg/lapack'
+
+CLOBBER.include('lib/numo/linalg/site_conf.rb')
+task :compile do
+  site_conf = Dir['./tmp/**/numo/linalg/blas/**/lib/site_conf.rb'].first
+  cp site_conf, 'lib/numo/linalg'
+end
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = '--color --format documentation --require spec_helper'
+end
+
+task :default => [:clobber, :compile, :spec]

--- a/ext/numo/linalg/blas/depend.erb
+++ b/ext/numo/linalg/blas/depend.erb
@@ -1,5 +1,5 @@
-COGEN=ruby gen/cogen.rb -l
-GENDEPS=gen/*.rb tmpl/*.c
+COGEN=<%= "ruby #{__dir__}/gen/cogen.rb -l" %>
+GENDEPS=<%= "#{__dir__}/gen/*.rb #{__dir__}/tmpl/*.c" %>
 
 <%
 srcs = %w[s d c z].map{|c| [c, "blas_#{c}.c"]}

--- a/ext/numo/linalg/blas/extconf.rb
+++ b/ext/numo/linalg/blas/extconf.rb
@@ -36,5 +36,5 @@ elsif have_header("windows.h")
 end
 
 create_site_conf
-create_depend
+create_depend(__dir__)
 create_makefile('numo/linalg/blas')

--- a/ext/numo/linalg/lapack/depend.erb
+++ b/ext/numo/linalg/lapack/depend.erb
@@ -1,5 +1,5 @@
-COGEN=ruby gen/cogen.rb -l
-GENDEPS=gen/*.rb tmpl/*.c
+COGEN=<%= "ruby #{__dir__}/gen/cogen.rb -l" %>
+GENDEPS=<%= "#{__dir__}/gen/*.rb #{__dir__}/tmpl/*.c" %>
 
 <%
 srcs = %w[s d c z].map{|c| [c, "lapack_#{c}.c"]}

--- a/ext/numo/linalg/lapack/extconf.rb
+++ b/ext/numo/linalg/lapack/extconf.rb
@@ -36,5 +36,5 @@ elsif have_header("windows.h")
   exit(1) unless have_func("LoadLibrary")
 end
 
-create_depend
+create_depend(__dir__)
 create_makefile('numo/linalg/lapack')

--- a/ext/numo/linalg/mkmf_linalg.rb
+++ b/ext/numo/linalg/mkmf_linalg.rb
@@ -69,12 +69,12 @@ def find_libnarray_a
   end
 end
 
-def create_depend
+def create_depend(base_dir)
   require 'erb'
   message "creating depend\n"
-  dep_path = File.join(Dir.pwd, "depend")
+  dep_path = "#{base_dir}/depend"
   File.open(dep_path, "w") do |dep|
-    dep_erb_path = File.join(Dir.pwd, "depend.erb")
+    dep_erb_path = "#{base_dir}/depend.erb"
     File.open(dep_erb_path, "r") do |dep_erb|
       erb = ERB.new(dep_erb.read)
       erb.filename = dep_erb_path

--- a/numo-linalg.gemspec
+++ b/numo-linalg.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "rspec"
   spec.add_runtime_dependency "numo-narray", ">= 0.9.1.4"
 end


### PR DESCRIPTION
I would like to add rake-compiler gem to make the build easy like Numo::NArray. By merging this pull request, native extensions can be built with rake command:

```
$ bundle exec rake compile
mkdir -p tmp/x86_64-darwin20/numo/linalg/blas/3.0.0/numo/linalg
cd tmp/x86_64-darwin20/numo/linalg/blas/3.0.0
/Users/foo/.anyenv/envs/rbenv/versions/3.0.0/bin/ruby -I. ../../../../../../ext/numo/linalg/blas/extconf.rb
checking for numo/narray.h... yes
...
```

This changes do not affect the gem creation with the previous method:

```
$ bundle exec rake build
numo-linalg 0.1.5 built to pkg/numo-linalg-0.1.5.gem.

$ gem install pkg/numo-linalg-0.1.5.gem
Building native extensions. This could take a while...
Successfully installed numo-linalg-0.1.5
Parsing documentation for numo-linalg-0.1.5
Done installing documentation for numo-linalg after 7 seconds
1 gem installed
```

I hope you will consider it for improving developer experience.