### PR TITLE
Add 3.0 and Head to the version of Ruby running in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,41 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build:
+  release-versions:
+    name: Build on ruby-${{ matrix.ruby }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
     steps:
       - uses: actions/checkout@v2
       - name: Install BLAS and LAPACK
         run: sudo apt-get install -y libopenblas-dev liblapacke-dev
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Build and test with Rake
+        run: |
+          gem install --no-document bundler
+          bundle install --jobs 4 --retry 3
+          bundle exec rake
+
+  ruby-head:
+    name: Build on ruby-head
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ 'debug' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install BLAS and LAPACK
+        run: sudo apt-get install -y libopenblas-dev liblapacke-dev
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and test with Rake

--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -26,8 +26,8 @@ module Numo
         lapacke_dirs = ['/opt/lapack/lib', '/opt/lapack/lib64', '/opt/local/lib/lapack',
                         '/usr/local/opt/lapack/lib']
         opt_dirs =  ['/opt/local/lib', '/opt/local/lib64', '/opt/lib', '/opt/lib64']
-        base_dirs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64',
-                     "/usr/lib/#{RbConfig::CONFIG['host_cpu']}-#{RbConfig::CONFIG['host_os']}"]
+        base_dirs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64']
+        base_dirs.concat(Dir["/usr/lib/#{RbConfig::CONFIG['host_cpu']}-*"])
         base_dirs.unshift(*ENV['LD_LIBRARY_PATH'].split(':')) unless ENV['LD_LIBRARY_PATH'].nil?
 
         mkl_libs = find_mkl_libs([*base_dirs, *opt_dirs, *mkl_dirs])


### PR DESCRIPTION
I would like to add Ruby 3.0 and Head to CI like Numo::NArray. As a result of the added test, I found a variation in the notation of Linux OS in RbConfig::CONFIG['host_os'], so I fixed the library directory searched by autoloader.

