### PR TITLE
Tweak autoloader for Windows

### DIFF
--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -64,7 +64,12 @@ module Numo
       end
 
       def detect_library_extension
-        case RbConfig::CONFIG['host_os']
+        # Ruby >= 2.5 provides SOEXT in rbconfig
+        so_ext = RbConfig::CONFIG["SOEXT"]
+        return so_ext if so_ext
+
+        # For Ruby < 2.5, we use RUBY_PLATFORM
+        case RUBY_PLATFORM
         when /mswin|msys|mingw|cygwin/
           'dll'
         when /darwin|mac os/

--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -68,14 +68,23 @@ module Numo
         so_ext = RbConfig::CONFIG["SOEXT"]
         return so_ext if so_ext
 
+        return 'dll' if windows?
+
         # For Ruby < 2.5, we use RUBY_PLATFORM
         case RUBY_PLATFORM
-        when /mswin|msys|mingw|cygwin/
-          'dll'
         when /darwin|mac os/
           'dylib'
         else
           'so'
+        end
+      end
+
+      def windows?
+        case RUBY_PLATFORM
+        when /mswin|msys|mingw|cygwin/
+          true
+        else
+          false
         end
       end
 
@@ -87,17 +96,36 @@ module Numo
         lib_ext = detect_library_extension
         lib_arr = lib_names.map do |l|
           x = nil
-          lib_dirs.find do |d|
-            x = Dir.glob("#{d}/lib#{l}{,64}.#{lib_ext}{,.*}").find do |lib|
+          if windows?
+            # On Windows, try to search the default DLL search path at first
+            [
+              "lib#{l}.#{lib_ext}",
+              "lib#{l}64.#{lib_ext}"
+            ].each do |filename|
               begin
-                Fiddle.dlopen(lib).close
+                Fiddle.dlopen(filename).close
               rescue Fiddle::DLError
-                false
+                x = nil
               else
-                true
+                x = filename
+                break
               end
             end
-            break if x
+          end
+          if x.nil?
+            # Search in the candidate directories
+            lib_dirs.find do |d|
+              x = Dir.glob("#{d}/lib#{l}{,64}.#{lib_ext}{,.*}").find do |lib|
+                begin
+                  Fiddle.dlopen(lib).close
+                rescue Fiddle::DLError
+                  false
+                else
+                  true
+                end
+              end
+              break if x
+            end
           end
           [l.to_sym, x]
         end

--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -82,8 +82,17 @@ module Numo
         lib_ext = detect_library_extension
         lib_arr = lib_names.map do |l|
           x = nil
-          lib_dirs.each do |d|
-            break if x = Dir.glob("#{d}/lib#{l}{,64}.#{lib_ext}{,.*}").last
+          lib_dirs.find do |d|
+            x = Dir.glob("#{d}/lib#{l}{,64}.#{lib_ext}{,.*}").find do |lib|
+              begin
+                Fiddle.dlopen(lib).close
+              rescue Fiddle::DLError
+                false
+              else
+                true
+              end
+            end
+            break if x
           end
           [l.to_sym, x]
         end


### PR DESCRIPTION
This change tweaks the autoloader for Windows, especially for Ruby Installer 2.

Ruby Installer 2 adds the bin directory of its MSYS2 (a.k.a. DEVKIT) in the default DLL search directories.  This directory is the location of the DLLs installed by pacman command.

If we try libraries only with their names like `Fiddle.dlopen("libopenblas.dll")` first, the autoloader makes it easier to use libraries installed by pacman command.