### PR TITLE
Fix to use conditional expressions on ger and syr2k methods

### DIFF
--- a/ext/numo/linalg/blas/tmpl/ger.c
+++ b/ext/numo/linalg/blas/tmpl/ger.c
@@ -83,7 +83,7 @@ static VALUE
 
     SWAP_IFCOL(g.order, mx,ny, tmp);
 
-    if (a == Qnil) { // c is not given.
+    if (a == Qnil) { // a is not given.
         ndf.nout = 1;
         ain[2] = ain[3];
         a = INT2FIX(0);
@@ -92,6 +92,7 @@ static VALUE
     } else {
         narray_t  *na3;
         blasint    ma, na;
+        SET_INPLACE(a);
         COPY_OR_CAST_TO(a,cT);
         GetNArray(a,na3);
         CHECK_DIM_GE(na3,2);
@@ -103,9 +104,10 @@ static VALUE
 
     ans = na_ndloop3(&ndf, &g, 3, x, y, a);
 
-    if (ndf.nout = 1) { // a is not given.
+    if (ndf.nout == 1) { // a is not given.
         return ans;
     } else {
+        UNSET_INPLACE(a);
         return a;
     }
 }

--- a/ext/numo/linalg/blas/tmpl/syr2k.c
+++ b/ext/numo/linalg/blas/tmpl/syr2k.c
@@ -106,6 +106,7 @@ static VALUE
         shape[0] = nb;
         shape[1] = na;
     } else {
+        SET_INPLACE(c);
         COPY_OR_CAST_TO(c,cT);
         GetNArray(c,na3);
         CHECK_DIM_GE(na3,2);
@@ -118,9 +119,10 @@ static VALUE
 
     ans = na_ndloop3(&ndf, &g, 3, a, b, c);
 
-    if (ndf.nout = 1) { // c is not given.
+    if (ndf.nout == 1) { // c is not given.
         return ans;
     } else {
+        UNSET_INPLACE(c);
         return c;
     }
 }

--- a/spec/linalg/blas_spec.rb
+++ b/spec/linalg/blas_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Numo::Linalg::Blas do
+  describe 'ger' do
+    describe 'SFloat' do
+      subject(:err) { (a - Numo::SFloat[[3, 4, 5], [6, 8, 10]]).sum.abs }
+
+      let(:x) { Numo::SFloat[1, 2] }
+      let(:y) { Numo::SFloat[3, 4, 5] }
+
+      context 'when a is given' do
+        let(:a) { Numo::SFloat.zeros(2, 3) }
+
+        it 'calculates row and column vectors product' do
+          Numo::Linalg::Blas.call(:ger, x, y, a)
+          expect(err).to be < ERR_TOL
+        end
+      end
+
+      context 'when a is not given' do
+        let(:a) { Numo::Linalg::Blas.call(:ger, x, y) }
+
+        it 'calculates row and column vectors product' do
+          expect(err).to be < ERR_TOL
+        end
+      end
+    end
+
+    describe 'DFloat' do
+      subject(:err) { (a - Numo::DFloat[[3, 4, 5], [6, 8, 10]]).sum.abs }
+
+      let(:x) { Numo::DFloat[1, 2] }
+      let(:y) { Numo::DFloat[3, 4, 5] }
+
+      context 'when a is given' do
+        let(:a) { Numo::DFloat.zeros(2, 3) }
+
+        it 'calculates row and column vectors product' do
+          Numo::Linalg::Blas.call(:ger, x, y, a)
+          expect(err).to be < ERR_TOL
+        end
+      end
+
+      context 'when a is not given' do
+        let(:a) { Numo::Linalg::Blas.call(:ger, x, y) }
+
+        it 'calculates row and column vectors product' do
+          expect(err).to be < ERR_TOL
+        end
+      end
+    end
+  end
+
+  describe 'syr2k' do
+    describe 'SFloat' do
+      subject(:err) { (c - Numo::SFloat[[50, 78, 106], [0, 90, 102], [0, 0, 98]]).sum.abs } # NOTE: syr2k returns only the upper triangular part of C.
+
+      let(:a) { Numo::SFloat[[1, 2], [3, 4], [5, 6]] }
+      let(:b) { Numo::SFloat[[9, 8], [7, 6], [5, 4]] }
+
+      context 'when c is given' do
+        let(:c) { Numo::SFloat.zeros(3, 3) }
+
+        it 'performs a rank-2k matrix-matrix operation: C = A * B.T + B * A.T' do
+          Numo::Linalg::Blas.call(:syr2k, a, b, c)
+          expect(err).to be < ERR_TOL
+        end
+      end
+
+      context 'when c is not given' do
+        let(:c) { Numo::Linalg::Blas.call(:syr2k, a, b) }
+
+        it 'performs a rank-2k matrix-matrix operation: A * B.T + B * A.T' do
+          expect(err).to be < ERR_TOL
+        end
+      end
+    end
+
+    describe 'DFloat' do
+      subject(:err) { (c - Numo::DFloat[[50, 78, 106], [0, 90, 102], [0, 0, 98]]).sum.abs }
+
+      let(:a) { Numo::DFloat[[1, 2], [3, 4], [5, 6]] }
+      let(:b) { Numo::DFloat[[9, 8], [7, 6], [5, 4]] }
+
+      context 'when c is given' do
+        let(:c) { Numo::DFloat.zeros(3, 3) }
+
+        it 'performs a rank-2k matrix-matrix operation: C = A * B.T + B * A.T' do
+          Numo::Linalg::Blas.call(:syr2k, a, b, c)
+          expect(err).to be < ERR_TOL
+        end
+      end
+
+      context 'when c is not given' do
+        let(:c) { Numo::Linalg::Blas.call(:syr2k, a, b) }
+
+        it 'performs a rank-2k matrix-matrix operation: A * B.T + B * A.T' do
+          expect(err).to be < ERR_TOL
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When building numo-linalg, the apple clang compiler v13.1.6 displays parentheses warnings:

```
ext/numo/linalg/blas/gen/../tmpl/ger.c:108:18: warning: using the result of an assignment as a c
ondition without parentheses [-Wparentheses]
    if (ndf.nout = 1) { // a is not given.
        ~~~~~~~~~^~~

...

ext/numo/linalg/blas/gen/../tmpl/syr2k.c:127:18: warning: using the result of an assignment as a
 condition without parentheses [-Wparentheses]
    if (ndf.nout = 1) { // c is not given.
        ~~~~~~~~~^~~
```

I think that a conditional expression is more appropriate than an assignment expression and have fixed it as such.