### PR TITLE
Add dynamic_lookup linker option for macOS and Ruby 3.1

### DIFF
--- a/ext/numo/linalg/blas/extconf.rb
+++ b/ext/numo/linalg/blas/extconf.rb
@@ -28,6 +28,12 @@ if RUBY_PLATFORM =~ /mswin|cygwin|mingw/
   end
 end
 
+if RUBY_PLATFORM.match?(/darwin/) && Gem::Version.new('3.1.0') <= Gem::Version.new(RUBY_VERSION)
+  if try_link('int main(void){return 0;}', '-Wl,-undefined,dynamic_lookup')
+    $LDFLAGS << ' -Wl,-undefined,dynamic_lookup'
+  end
+end
+
 if have_header("dlfcn.h")
   exit(1) unless have_library("dl")
   exit(1) unless have_func("dlopen")

--- a/ext/numo/linalg/lapack/extconf.rb
+++ b/ext/numo/linalg/lapack/extconf.rb
@@ -29,6 +29,12 @@ if RUBY_PLATFORM =~ /cygwin|mingw/
   end
 end
 
+if RUBY_PLATFORM.match?(/darwin/) && Gem::Version.new('3.1.0') <= Gem::Version.new(RUBY_VERSION)
+  if try_link('int main(void){return 0;}', '-Wl,-undefined,dynamic_lookup')
+    $LDFLAGS << ' -Wl,-undefined,dynamic_lookup'
+  end
+end
+
 if have_header("dlfcn.h")
   exit(1) unless have_library("dl")
   exit(1) unless have_func("dlopen")


### PR DESCRIPTION
Installation of Numo::Linalg fails with Xcode14 and Ruby 3.1 as follows:

```sh
$ xcodebuild -version
Xcode 14.1
Build version 14B47b
$ ruby -v
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin21]
$ gem install numo-linalg
Fetching numo-linalg-0.1.7.gem
Building native extensions. This could take a while...
ERROR:  Error installing numo-linalg:
        ERROR: Failed to build gem native extension.

...

ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [blas.bundle] Error 1

make failed, exit code 2
```

The cause is the same as the bug fixed in Ruby3.1.3.

https://www.ruby-lang.org/ja/news/2022/11/24/ruby-3-1-3-released/
https://bugs.ruby-lang.org/issues/18912

To fix this bug, add the `-undefined dynamic_lookup` option when building with macOS and Ruby 3.1.

https://github.com/ruby/ruby/pull/6440/commits/881e9c83df17f55f56c4cc2de1b7b3c31599fea4

However, since the following warning message is displayed, so I add a check for the validity of the option via the try_link method  to avoid future build failures.

```sh
...

linking shared-object numo/linalg/lapack.bundle
ld: warning: -undefined dynamic_lookup may not work with chained fixups

...
```

Please consider this pull request for macOS users. Thank you.
