### PR TITLE
Migrate to ruby/setup-ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
       - uses: actions/checkout@v2
       - name: Install BLAS and LAPACK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
       - uses: actions/checkout@v2
       - name: Install BLAS and LAPACK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install BLAS and LAPACK
         run: sudo apt-get install -y libopenblas-dev liblapacke-dev
       - name: Set up Ruby ${{ matrix.ruby }}
@@ -33,7 +33,7 @@ jobs:
       matrix:
         ruby: [ 'debug' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install BLAS and LAPACK
         run: sudo apt-get install -y libopenblas-dev liblapacke-dev
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install BLAS and LAPACK
         run: sudo apt-get install -y libopenblas-dev liblapacke-dev
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and test with Rake


### PR DESCRIPTION
This pull request aims to fix failing builds: https://github.com/ruby-numo/numo-linalg/actions/runs/3911069400

Since the actions/ruby-setup is deprecated, I would like to migrate to  the ruby/ruby-setup. In addition, I have added Ruby v3.1 and v3.2, removed v2.6 which the latest Bundler does not support, and bumped the actions/checkout to v3.
I would appreciate your kind consideration.