### PR TITLE
Add MacOS autoload paths for openblas/lapack for new homebrew

### DIFF
--- a/lib/numo/linalg/autoloader.rb
+++ b/lib/numo/linalg/autoloader.rb
@@ -20,11 +20,11 @@ module Numo
       def load_library
         mkl_dirs = ['/opt/intel/lib', '/opt/intel/lib64', '/opt/intel/mkl/lib', '/opt/intel/mkl/lib64']
         openblas_dirs = ['/opt/OpenBLAS/lib', '/opt/OpenBLAS/lib64', '/opt/openblas/lib', '/opt/openblas/lib64',
-                         '/usr/local/opt/openblas/lib']
+                         '/usr/local/opt/openblas/lib', '/opt/homebrew/opt/openblas/lib']
         atlas_dirs = ['/opt/atlas/lib', '/opt/atlas/lib64',
                       '/usr/lib/atlas', '/usr/lib64/atlas', '/usr/local/opt/atlas/lib']
         lapacke_dirs = ['/opt/lapack/lib', '/opt/lapack/lib64', '/opt/local/lib/lapack',
-                        '/usr/local/opt/lapack/lib']
+                        '/usr/local/opt/lapack/lib', '/opt/homebrew/opt/lapack/lib']
         opt_dirs =  ['/opt/local/lib', '/opt/local/lib64', '/opt/lib', '/opt/lib64']
         base_dirs = ['/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64']
         base_dirs.concat(Dir["/usr/lib/#{RbConfig::CONFIG['host_cpu']}-*"])


### PR DESCRIPTION
My newer mac can not find paths like my old mac.
"cannot find MKL/OpenBLAS/ATLAS/BLAS-LAPACK library"

It appears new versions of Homebrew has new locations where it stores these files.
Could we please add these new search paths?